### PR TITLE
Run tests on PHPUnit 9, on PHP 7.4 and add .gitattributes to exclude dev files from exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
+/tests export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ install:
   - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,26 @@
 language: php
 
-php:
-# - 5.3 # requires old distro, see below
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - hhvm # ignore errors, see below
-
 # lock distro so future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
+    - php: hhvm-3.18
   allow_failures:
-    - php: hhvm
-
-sudo: false
+    - php: hhvm-3.18
 
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
   - vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,16 @@
         "clue/graph": "~0.9.0|~0.8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "autoload": {
-        "psr-4": {"Graphp\\TrivialGraphFormat\\": "src/"}
+        "psr-4": {
+            "Graphp\\TrivialGraphFormat\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Graph\\Tests\\TrivialGraphFormat\\": "tests/"
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
->
+<phpunit bootstrap="vendor/autoload.php" 
+         colors="true" 
+         cacheResult="false">
     <testsuites>
         <testsuite name="TGF Test Suite">
             <directory>./tests/</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" 
-         colors="true" 
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
          cacheResult="false">
     <testsuites>
         <testsuite name="TGF Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="TGF Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/TrivialGraphFormatTest.php
+++ b/tests/TrivialGraphFormatTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Graph\Tests\TrivialGraphFormat;
+
 use Fhaculty\Graph\Graph;
 use Graphp\TrivialGraphFormat\TrivialGraphFormat;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
For further details concerning this pull request look into [graphp/graphviz #46](https://github.com/graphp/graphviz/pull/46).